### PR TITLE
Camp replacement queue handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -17,7 +17,7 @@ if DEBUG:
     set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 intents = discord.Intents.default()
-intents.members = True
+#intents.members = True
 UrnbyBot = discord.Bot(intents=intents)
 
 cogs_list = [
@@ -31,7 +31,7 @@ cogs_list = [
 
 
 @UrnbyBot.event
-async def on_ready():    
+async def on_ready():
     print(f"{UrnbyBot.user} is online!")
     '''
     if DEBUG == "True":

--- a/bot.py
+++ b/bot.py
@@ -16,8 +16,8 @@ if DEBUG:
     from asyncio import set_event_loop_policy, WindowsSelectorEventLoopPolicy
     set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
-#intents = discord.Intents.members + discord.Intents.default()
 intents = discord.Intents.default()
+intents.members = True
 UrnbyBot = discord.Bot(intents=intents)
 
 cogs_list = [
@@ -29,8 +29,9 @@ cogs_list = [
     'tod',
 ]
 
+
 @UrnbyBot.event
-async def on_ready():
+async def on_ready():    
     print(f"{UrnbyBot.user} is online!")
     '''
     if DEBUG == "True":

--- a/cogs/campqueue.py
+++ b/cogs/campqueue.py
@@ -12,8 +12,6 @@ from pathlib import Path
 # Internal
 import data.databaseapi as db
 
-CLASSES = json.load(open('static/classes.json', 'r', encoding='utf-8'))
-
 class CampQueue(commands.Cog):
     
     def __init__(self, bot):
@@ -29,7 +27,7 @@ class CampQueue(commands.Cog):
         if ctx.guild is None:
             await ctx.send_response(content='This command can not be used in Direct Messages')
             return
-        reps = await db.get_replacement_list(ctx.guild.id)
+        reps = await db.get_replacement_queue(ctx.guild.id)
 
         # Make Pretty.
         content = '_ _\nCurrent replacement order: '
@@ -44,7 +42,6 @@ class CampQueue(commands.Cog):
         now = datetime.datetime.now(tz)
         rep = {
             'user': ctx.author.id,
-            'name': ctx.author.display_name,
             'in_timestamp': int(now.timestamp())
         }
         added = await db.add_replacement(ctx.guild.id, rep)

--- a/cogs/campqueue.py
+++ b/cogs/campqueue.py
@@ -1,16 +1,20 @@
 # Builtin
 import datetime
-import json
 
 # External
 import discord
 from discord.ext import commands
 from pytz import timezone
 tz = timezone('EST')
-from pathlib import Path
 
 # Internal
 import data.databaseapi as db
+from checks.IsAdmin import is_admin, NotAdmin
+from checks.IsCommandChannel import is_command_channel, NotCommandChannel
+from checks.IsMemberVisible import is_member_visible, NotMemberVisible
+from checks.IsMember import is_member, NotMember
+from checks.IsInDev import is_in_dev, InDevelopment
+
 
 class CampQueue(commands.Cog):
     
@@ -22,44 +26,140 @@ class CampQueue(commands.Cog):
     async def on_connect(self):
         print(f'campqueue connected to discord')
 
-    @commands.slash_command(name='getqueue')
-    async def _getcampqueue(self, ctx):
+    @commands.Cog.listener()
+    async def on_ready(self):
+        missing_tables = await db.check_tables(['reps'])
+        if missing_tables:
+            print(f"Warning, missing the following tables in db: {missing_tables}")
+    
+    async def cog_before_invoke(self, ctx):
+        now = datetime.datetime.now(tz)
+        now = now.replace(microsecond = 0)
+        guild_id = None
+        if not ctx.guild:
+            guild_id = 'DM'
+        else:
+            guild_id = ctx.guild.id
+        print(f'{now.isoformat()} [{guild_id}] - Command {ctx.command.qualified_name} by {ctx.author.name} - {ctx.author.id}', flush=True)
+        command = {'command_name': ctx.command.qualified_name, 'options': str(ctx.selected_options), 'datetime': now.isoformat(), 'user': ctx.author.id, 'user_name': ctx.author.name, 'channel_name': ctx.channel.name}
+        await db.store_command(guild_id, command)
+        return
+
+    # ==============================================================================
+    # Error Handlers
+    # ==============================================================================
+    async def cog_command_error(self, ctx: commands.Context, error: commands.CommandError):
+        now = datetime.datetime.now(tz).replace(microsecond = 0)
+        guild_id = None
+        channel_name = None
+        if not ctx.guild:
+            guild_id = 'DM'
+            channel_name = 'DM'
+        else:
+            guild_id = ctx.guild.id
+            channel_name = ctx.channel.name
+        print(f'{now.isoformat()} [{guild_id}] - Error in command {ctx.command.qualified_name} by {ctx.author.name} - {ctx.author.id} {error}', flush=True)
+        _error = {
+            'level': 'error', 
+            'command_name': ctx.command.qualified_name, 
+            'options': str(ctx.selected_options), 
+            'author_id': ctx.author.id, 
+            'author_name': ctx.author.name, 
+            'channel_name': channel_name, 
+            'error': str(type(error)),
+        }
+        
+        if isinstance(error, NotAdmin):
+            await ctx.send_response(content=f"You do not have permissions to use this function, {ctx.command} - {ctx.selected_options}")
+            return
+        elif isinstance(error, NotCommandChannel):
+            await ctx.send_response(content=f"You can not perform this command in this channel", ephemeral=True)
+            return
+        elif isinstance(error, NotMemberVisible):
+            await ctx.send_response(content=f"This command can not be performed where other members can not see the command", ephemeral=True)
+            return
+        elif isinstance(error, NotMember):
+            await ctx.send_response(content=f"You must be a member of higher privileges to invoke this command", ephemeral=False)
+            return
+        elif isinstance(error, InDevelopment):
+            await ctx.send_response(content=f"This function is unavailable due to it's development status", ephemeral=True)
+            return
+        else:
+            print(type(error), flush=True)
+            raise error
+        return
+
+    @commands.slash_command(name='getreps', description='Display current list of replacements')
+    @is_member()
+    async def _getreps(self, ctx, public: discord.Option(bool, name='public', default=False)):
         if ctx.guild is None:
             await ctx.send_response(content='This command can not be used in Direct Messages')
             return
-        reps = await db.get_replacement_queue(ctx.guild.id)
 
-        # Make Pretty.
-        content = '_ _\nCurrent replacement order: '
+        reps = await db.get_replacement_queue(ctx.guild.id)
+        content = '\nCurrent replacements: '
         for rep in reps:
             content += f'<@{rep["user"]}> --> '
         content += f'<END>'
-        await ctx.send_response(content=content, ephemeral=False, allowed_mentions=discord.AllowedMentions(users=False))
+        await ctx.send_response(content=content, ephemeral=not public, allowed_mentions=discord.AllowedMentions(users=False))
 
 
-    @commands.slash_command(name='campenqueue')
-    async def _campenqueue(self, ctx):
+    @commands.slash_command(name='rep', description='Add yourself to the replacement list (FIFO)')
+    @is_member()
+    @is_command_channel()
+    async def _rep(self, ctx, userid: discord.Option(str, name="userid", required=False)):
         now = datetime.datetime.now(tz)
+
+        if userid:
+            userid = int(userid)
+            try:
+                user = await ctx.guild.fetch_member(userid)
+            except discord.errors.NotFound:
+                await ctx.send_response(content=f'Invalid User ID')
+                return
+            else:
+                display_name = user.display_name
+        else:
+            display_name = ctx.author.display_name
+            
         rep = {
-            'user': ctx.author.id,
+            'user': userid if userid else ctx.author.id,
+            'name': display_name,
             'in_timestamp': int(now.timestamp())
         }
+
         added = await db.add_replacement(ctx.guild.id, rep)
         if added is not None:
-            await ctx.send_response(content=f'{ctx.author.display_name} Successfully added to replacement queue')
+            await ctx.send_response(content=f'{display_name} Successfully added to replacement queue')
         else:
-            await ctx.send_response(content=f'You are already in the queue')
+            await ctx.send_response(content=f'User is already in queue')
     
-    @commands.slash_command(name='campdequeue')
-    async def _campdequeue(self, ctx):
-        removed = await db.remove_replacement(ctx.guild.id, ctx.author.id)
-        if removed is not None:
-            await ctx.send_response(content=f'{ctx.author.display_name} Successfully removed from replacement queue')
-        else:
-            await ctx.send_response(content=f'You are not in the queue')
+    @commands.slash_command(name='unrep', description='Remove yourself from the replacement list')
+    @is_member()
+    @is_command_channel()
+    async def _unrep(self, ctx, userid: discord.Option(str, name="userid", required=False)):
 
-    @commands.slash_command(name='admin_campenqueue')
-    async def _admincampenqueue(self, ctx,
+        if userid:
+            userid = int(userid)
+            try:
+                user = await ctx.guild.fetch_member(userid)
+            except discord.errors.NotFound:
+                await ctx.send_response(content=f'Invalid User ID')
+                return
+            else:
+                display_name = user.display_name
+        else:
+            display_name = ctx.author.display_name
+
+        removed = await db.remove_replacement(ctx.guild.id, userid if userid else ctx.author.id)
+        if removed is not None:
+            await ctx.send_response(content=f'{display_name} Successfully removed from replacement queue')
+        else:
+            await ctx.send_response(content=f'User is not in queue')
+
+    @commands.slash_command(name='admin_rep')
+    @is_admin()
+    async def _adminrep(self, ctx,
                 _userid: discord.Option(int, name="userid", required=True),
                 intime: discord.Option(int, name="intime", required=False, default=0)):
 
@@ -74,14 +174,16 @@ class CampQueue(commands.Cog):
         await db.add_replacement(ctx.guild.id, rep)
         await ctx.send_response(content=f'Added.')
         
-    @commands.slash_command(name='admin_campdequeue')
-    async def _admincampdequeue(self, ctx,
+    @commands.slash_command(name='admin_unrep')
+    @is_admin()
+    async def _adminunrep(self, ctx,
                 _userid: discord.Option(str, name="userid", required=True)):
         await db.remove_replacement(ctx.guild.id, _userid)
         await ctx.send_response(content=f'Removed.')
 
-    @commands.slash_command(name='admin_campqueueflush')
-    async def _admincampqueueflush(self, ctx):
+    @commands.slash_command(name='admin_clearreps')
+    @is_admin()
+    async def _adminclearreps(self, ctx):
         await db.clear_replacement_queue(ctx.guild.id)
         await ctx.send_response(content=f'Queue cleared.')
 

--- a/cogs/clocks.py
+++ b/cogs/clocks.py
@@ -37,16 +37,8 @@ class Clocks(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.state_lock = asyncio.Lock()
-        
         print('Initilization on clocks complete', flush=True)
     
-    def cog_check(self, ctx):
-        if ctx.guild is None:
-            raise NotCommandChannel()
-        config = self.get_config(ctx.guild.id)
-        if ctx.channel_id in config['command_channels']:
-            return True
-        raise NotCommandChannel()
     
     @commands.Cog.listener()
     async def on_ready(self):

--- a/cogs/dashboard.py
+++ b/cogs/dashboard.py
@@ -137,8 +137,8 @@ class Dashboard(commands.Cog):
                 else:
                     mins_till_ds_str = f'{mins_till_ds:4}mins'
             #TODO get camp queue
-            camp_queue = []
-            contentlines = ["```\n"]
+            camp_queue = await db.get_replacement_queue(guild.id)
+            contentlines = ["\n```"]
             contentlines.append(f" {'Active Session':33}DS in: {mins_till_ds_str:8}|")
             contentlines.append(f"{'-'*49}-")
             contentlines.append(f" {session['session'][:27]:27} @ {timestr:13} EST |")
@@ -148,10 +148,11 @@ class Dashboard(commands.Cog):
             for item in actives:
                 contentlines.append(f" {item['display_name'][:29]:30} {item['delta']:17.2f}|")
             contentlines.append(f"{'-'*49}|")
-            contentlines.append(f" {'Camp Queue':33}Hours available|")
+            contentlines.append(f" {'Camp Queue':48}|")
             contentlines.append(f"{'-'*49}|")
             for item in camp_queue:
-                contentlines.append(f" {item['display_name'][:29]:30} {item['delta']:17.2f}|")
+                user = await guild.fetch_member(item["user"])
+                contentlines.append(f" {user.display_name[:29]:47} |")
             lines = 2
             ex_lines = 7
             cont_lines = len(actives) + len(camp_queue)
@@ -172,10 +173,10 @@ class Dashboard(commands.Cog):
                 
             channel = await guild.fetch_channel(config['dashboard_channel'])
             if not session_real:
-                await channel.send(content=content+"Paused till session start", silent=True)
+                await channel.send(content=content+"Paused till session start", silent=True, allowed_mentions=discord.AllowedMentions(users=False))
                 self.delay[guild.id] = True
             else:
-                await channel.send(content=content, delete_after=REFRESH_TIME+.5, silent=True)
+                await channel.send(content=content, delete_after=REFRESH_TIME+.5, silent=True, allowed_mentions=discord.AllowedMentions(users=False))
                 self.delay[guild.id] = False
             
 

--- a/cogs/dashboard.py
+++ b/cogs/dashboard.py
@@ -136,8 +136,8 @@ class Dashboard(commands.Cog):
                     mins_till_ds_str = "Unknown"
                 else:
                     mins_till_ds_str = f'{mins_till_ds:4}mins'
-            #TODO get camp queue
-            camp_queue = await db.get_replacement_queue(guild.id)
+
+            reps = await db.get_replacement_queue(guild.id)
             contentlines = ["\n```"]
             contentlines.append(f" {'Active Session':33}DS in: {mins_till_ds_str:8}|")
             contentlines.append(f"{'-'*49}-")
@@ -148,14 +148,13 @@ class Dashboard(commands.Cog):
             for item in actives:
                 contentlines.append(f" {item['display_name'][:29]:30} {item['delta']:17.2f}|")
             contentlines.append(f"{'-'*49}|")
-            contentlines.append(f" {'Camp Queue':48}|")
+            contentlines.append(f" {'Rep List':48}|")
             contentlines.append(f"{'-'*49}|")
-            for item in camp_queue:
-                user = await guild.fetch_member(item["user"])
-                contentlines.append(f" {user.display_name[:29]:47} |")
+            for rep in reps:
+                contentlines.append(f" {rep['name'][:29]:47} |")
             lines = 2
             ex_lines = 7
-            cont_lines = len(actives) + len(camp_queue)
+            cont_lines = len(actives) + len(reps)
             
             #Appending 2nd column
             contentlines[1] += f" Top {ex_lines+cont_lines} in Hours\n"
@@ -173,10 +172,10 @@ class Dashboard(commands.Cog):
                 
             channel = await guild.fetch_channel(config['dashboard_channel'])
             if not session_real:
-                await channel.send(content=content+"Paused till session start", silent=True, allowed_mentions=discord.AllowedMentions(users=False))
+                await channel.send(content=content+"Paused till session start", silent=True)
                 self.delay[guild.id] = True
             else:
-                await channel.send(content=content, delete_after=REFRESH_TIME+.5, silent=True, allowed_mentions=discord.AllowedMentions(users=False))
+                await channel.send(content=content, delete_after=REFRESH_TIME+.5, silent=True)
                 self.delay[guild.id] = False
             
 

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -34,7 +34,7 @@ class Misc(commands.Cog):
             guild_id = 'DM'
         else:
             guild_id = ctx.guild.id
-        #print(f'{now.isoformat()} [{guild_id}] - Command {ctx.command.qualified_name} by {ctx.author.name} - {ctx.author.id} - {ctx.selected_options[0]["value"]}', flush=True)
+        print(f'{now.isoformat()} [{guild_id}] - Command {ctx.command.qualified_name} by {ctx.author.name} - {ctx.author.id} - {ctx.selected_options[0]["value"]}', flush=True)
         #command = {'command_name': ctx.command.qualified_name, 'options': str(ctx.selected_options), 'datetime': now.isoformat(), 'user': ctx.author.id, 'user_name': ctx.author.name, 'channel_name': ctx.channel.name}
         #await self.store_command(guild_id, command)
         return

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -9,6 +9,7 @@ from pytz import timezone
 tz = timezone('EST')
 
 # Internal
+import data.databaseapi as db
 from checks.IsAdmin import is_admin, NotAdmin
 from checks.IsCommandChannel import is_command_channel, NotCommandChannel
 from checks.IsMemberVisible import is_member_visible, NotMemberVisible
@@ -33,7 +34,7 @@ class Misc(commands.Cog):
             guild_id = 'DM'
         else:
             guild_id = ctx.guild.id
-        print(f'{now.isoformat()} [{guild_id}] - Command {ctx.command.qualified_name} by {ctx.author.name} - {ctx.author.id} - {ctx.selected_options[0]["value"]}', flush=True)
+        #print(f'{now.isoformat()} [{guild_id}] - Command {ctx.command.qualified_name} by {ctx.author.name} - {ctx.author.id} - {ctx.selected_options[0]["value"]}', flush=True)
         #command = {'command_name': ctx.command.qualified_name, 'options': str(ctx.selected_options), 'datetime': now.isoformat(), 'user': ctx.author.id, 'user_name': ctx.author.name, 'channel_name': ctx.channel.name}
         #await self.store_command(guild_id, command)
         return
@@ -92,6 +93,12 @@ class Misc(commands.Cog):
             res = "Succeeded"
         await ctx.send_response(f"Deletion of msgid {messageid} was {res}", ephemeral=True)
         
+    @commands.slash_command(name="initdb", description="Owner command, initialize db tables")
+    @commands.is_owner()
+    async def _init_db(self, ctx):
+        await db.init_database()
+        await ctx.send_response(content=f"Database initialized")
+
     @commands.slash_command(name='configadd')
     @is_admin()
     async def _add_config(self, ctx, 

--- a/data/databaseapi.py
+++ b/data/databaseapi.py
@@ -13,6 +13,29 @@ async def check_tables(tbls):
         return []
     return set(tbls) - set(l)
         
+async def init_database():
+    async with aiosqlite.connect('data/urnby.db') as db:
+        query = f"""CREATE TABLE IF NOT EXISTS "historical"(server, user, character, session, in_timestamp, out_timestamp, _DEBUG_user_name, _DEBUG_in, _DEBUG_out, _DEBUG_delta);"""
+        await db.execute(query)
+        await db.commit()
+        query = f"""CREATE TABLE IF NOT EXISTS "session"(server, session, created_by, _DEBUG_started_by, _DEBUG_start, start_timestamp, ended_by, _DEBUG_ended_by, _DEBUG_end, end_timestamp, _DEBUG_delta, hash);"""
+        await db.execute(query)
+        await db.commit()
+        query = f"""CREATE TABLE IF NOT EXISTS "session_history"(server,     session,  created_by, _DEBUG_started_by,   _DEBUG_start,  start_timestamp, ended_by, _DEBUG_ended_by,  _DEBUG_end, end_timestamp,      _DEBUG_delta);"""
+        await db.execute(query)
+        await db.commit()
+        query = f"""CREATE TABLE IF NOT EXISTS "active"(server, user, character, session, in_timestamp, out_timestamp, _DEBUG_user_name, _DEBUG_in, _DEBUG_out, _DEBUG_delta);"""
+        await db.execute(query)
+        await db.commit()
+        query = f"""CREATE TABLE IF NOT EXISTS "commands"(server, command_name, options, datetime, user, user_name, channel_name);"""
+        await db.execute(query)
+        await db.commit()
+        query = f"""CREATE TABLE IF NOT EXISTS "tod"(server, mob, tod_timestamp, submitted_timestamp, submitted_by_id, _DEBUG_submitted_datetime, _DEBUG_submitted_by, _DEBUG_tod_datetime);"""
+        await db.execute(query)
+        await db.commit()
+        query = f"""CREATE TABLE IF NOT EXISTS "reps"(server, user, name, in_timestamp, UNIQUE(server, user));"""
+        await db.execute(query)
+        await db.commit()
 
 async def flush_wal():
     async with aiosqlite.connect('data/urnby.db') as db:
@@ -298,7 +321,7 @@ async def store_tod(guild_id, info):
     # Replacement Queue
     # ============================================================================== 
 
-async def get_replacement_list(guild_id) -> list:
+async def get_replacement_queue(guild_id) -> list:
     res = []
     async with aiosqlite.connect('data/urnby.db') as db:
         db.row_factory = aiosqlite.Row
@@ -309,18 +332,17 @@ async def get_replacement_list(guild_id) -> list:
     return res
 
 async def add_replacement(guild_id, replacement):
-    current_rep_list = await get_replacement_list(guild_id)
-    for item in current_rep_list:
-        if item['user'] == replacement['user']:
-            return None
-            
     lastrow = 0
     async with aiosqlite.connect('data/urnby.db') as db:
-        query = f"""INSERT INTO reps(server,      user,  name, in_timestamp)
-                                VALUES({guild_id}, :user, :name, :in_timestamp)"""
-        async with db.execute(query, replacement) as cursor:
-            lastrow = cursor.lastrowid
-        await db.commit()
+        try:
+            query = f"""INSERT INTO reps(server,      user, in_timestamp)
+                                    VALUES({guild_id}, :user, :in_timestamp)"""
+            async with db.execute(query, replacement) as cursor:
+                lastrow = cursor.lastrowid
+        except aiosqlite.IntegrityError:
+            return None
+        else:
+            await db.commit()
     return lastrow
 
 async def remove_replacement(guild_id, user_id):

--- a/data/databaseapi.py
+++ b/data/databaseapi.py
@@ -335,8 +335,8 @@ async def add_replacement(guild_id, replacement):
     lastrow = 0
     async with aiosqlite.connect('data/urnby.db') as db:
         try:
-            query = f"""INSERT INTO reps(server,      user, in_timestamp)
-                                    VALUES({guild_id}, :user, :in_timestamp)"""
+            query = f"""INSERT INTO reps(server,      user, name, in_timestamp)
+                                    VALUES({guild_id}, :user, :name, :in_timestamp)"""
             async with db.execute(query, replacement) as cursor:
                 lastrow = cursor.lastrowid
         except aiosqlite.IntegrityError:

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Technical Info
 	dotenv - allows us to store secrets in environment, ignoreing the .env file to share code without sharing secrets (https://12factor.net/config)
 	pytz - Functionality for datetime timezones
 	aiosqlite - Non blocking wrapper for sqlite-python interfacing
+	persist-queue - thread safe file backed queue (file or sqlite options)
 	
 	SQLite has WAL mode enabled to allow concurrent read/writes (https://www.sqlite.org/walformat.html)
 	

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,6 @@ Technical Info
 	dotenv - allows us to store secrets in environment, ignoreing the .env file to share code without sharing secrets (https://12factor.net/config)
 	pytz - Functionality for datetime timezones
 	aiosqlite - Non blocking wrapper for sqlite-python interfacing
-	persist-queue - thread safe file backed queue (file or sqlite options)
 	
 	SQLite has WAL mode enabled to allow concurrent read/writes (https://www.sqlite.org/walformat.html)
 	


### PR DESCRIPTION

Adds following commands:

```
/getreps [public]
/rep [userid]
    - Default reps the issuer of cmd.
/unrep [userid]
    - Default unreps the issuer of cmd. 
/admin_clearreps
/admin_rep <userid> [in_time]
/admin_unrep <userid>
/initdb
     - Creates tables in db
```
![image](https://user-images.githubusercontent.com/46539635/224527309-32c63e11-f811-468b-a76b-c86d46847579.png)


Added rep list display to dashboard:
![image](https://user-images.githubusercontent.com/46539635/224527245-bf68fb86-18e3-41a6-bd7c-a33dac10628a.png)

A new `reps` table added to the DB:
`CREATE TABLE IF NOT EXISTS "reps"(server, user, name, in_timestamp, UNIQUE(server, user));`
