### PR TITLE
Order get reps by ASC (earliest timestamps first)

### DIFF
--- a/data/databaseapi.py
+++ b/data/databaseapi.py
@@ -326,7 +326,7 @@ async def get_replacement_queue(guild_id) -> list:
     res = []
     async with aiosqlite.connect('data/urnby.db') as db:
         db.row_factory = aiosqlite.Row
-        query = f"SELECT rowid, * FROM reps WHERE server = {guild_id} ORDER BY in_timestamp DESC"
+        query = f"SELECT rowid, * FROM reps WHERE server = {guild_id} ORDER BY in_timestamp"
         async with db.execute(query) as cursor:
             rows = await cursor.fetchall()
             res = [dict(row) for row in rows]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46539635/226231732-d0bc2c60-1429-4790-9a91-7e15ff4ddf0e.png)

dashboard, and /getreps is backwards (at least in my brain). The top of the list should be next for reps, and work its way down the list