### PR TITLE
Auto-remove "older than you" replacements when a rep clocks themselves in

### DIFF
--- a/cogs/campqueue.py
+++ b/cogs/campqueue.py
@@ -137,7 +137,11 @@ class CampQueue(commands.Cog):
             'in_timestamp': com.get_current_timestamp(),
         }
 
-        added = await self.add_rep(rep)
+        if await db.is_user_active(ctx.guild.id, userid):
+            await ctx.send_response(content=f'User is already clocked in')
+            return
+        
+        added = await self.add_rep(ctx, rep)
         if not added:
             await ctx.send_response(content=f'User is already in queue')
             return
@@ -151,7 +155,7 @@ class CampQueue(commands.Cog):
         userid, display_name = await get_userid_and_name(ctx, userid)
         if not userid:
             return
-        removed = await self.remove_rep(userid)
+        removed = await self.remove_rep(ctx, userid)
         if removed is None:
             await ctx.send_response(content=f'User is not in queue')
             return
@@ -165,7 +169,7 @@ class CampQueue(commands.Cog):
         userid, display_name = await get_userid_and_name(ctx, userid)
         if not userid:
             return
-        removed = await self.remove_rep(userid)
+        removed = await self.remove_rep(ctx, userid)
         if removed is None:
             await ctx.send_response(content=f'User is not in queue')
             return
@@ -178,7 +182,7 @@ class CampQueue(commands.Cog):
         userid, display_name = await get_userid_and_name(ctx, member.id)
         if not userid:
             return
-        removed = await self.remove_rep(userid)
+        removed = await self.remove_rep(ctx, userid)
         if removed is None:
             await ctx.send_response(content=f'User is not in queue')
             return

--- a/cogs/clocks.py
+++ b/cogs/clocks.py
@@ -33,6 +33,7 @@ class Clocks(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.state_lock = asyncio.Lock()
+        self.cq = self.bot.get_cog('CampQueue')
         print('Initilization on clocks complete', flush=True)
     
     
@@ -171,10 +172,15 @@ class Clocks(commands.Cog):
                 '_DEBUG_out': '',
                 '_DEBUG_delta': '',
             }
-        removed = await db.remove_replacement(ctx.guild.id, ctx.author.id)
+
+        older_reps = await cq.get_older_reps_than_user(ctx, ctx.author.id)
+        if older_reps:
+            await ctx.send_followup(f"There are older reps in list: {older_reps}")
+
+        rep_removed = await cq.remove_rep(ctx, ctx.author.id)
         
         content = f'{ctx.author.display_name} {com.scram("Successfully")} clocked in at <t:{doc["in_timestamp"]}:f>'
-        if removed is not None:
+        if rep_removed is not None:
             content += f' and was removed from replacement list'
         await db.store_active_record(ctx.guild.id, doc)
         await ctx.send_response(content=content)

--- a/cogs/clocks.py
+++ b/cogs/clocks.py
@@ -183,9 +183,11 @@ class Clocks(commands.Cog):
         await ctx.send_response(content=content)
         
         if older_reps:
+            content = f'Removing these replacements which are OLDER than this replacement:'
             for rep in older_reps:
                 await self.cq.remove_rep(ctx, rep['user'])
-            await ctx.send_followup(f"Removed older reps: {older_reps}")
+                content += f'\n<@{rep["user"]}>'
+            await ctx.send_followup(content=content)
 
         config = self.get_config(ctx.guild.id)
         if 'max_active' in config.keys() and config['max_active'] < len(actives)+1:

--- a/cogs/clocks.py
+++ b/cogs/clocks.py
@@ -186,7 +186,7 @@ class Clocks(commands.Cog):
             content = f'Removing these replacements which are OLDER than this replacement:'
             for rep in older_reps:
                 await self.cq.remove_rep(ctx, rep['user'])
-                content += f'\n<@{rep["user"]}>'
+                content += f'\n<@{rep["user"]}> @ {com.datetime_from_timestamp(rep["in_timestamp"]).isoformat()}'
             await ctx.send_followup(content=content)
 
         config = self.get_config(ctx.guild.id)

--- a/data/databaseapi.py
+++ b/data/databaseapi.py
@@ -371,6 +371,33 @@ async def clear_replacement_queue(guild_id):
         await db.commit()
     return lastrow
 
+async def get_replacement(guild_id, user_id):
+    res = {}
+    async with aiosqlite.connect('data/urnby.db') as db:
+        db.row_factory = aiosqlite.Row
+        query = f"SELECT * FROM reps WHERE server = {guild_id} AND user = {user_id}"
+        async with db.execute(query) as cursor:
+            rows = await cursor.fetchall()
+            if len(rows) < 1:
+                return None
+            res = dict(rows[0])
+    return res
+
+async def get_replacements_before_user(guild_id, user_id) -> list:
+
+    rep = await get_replacement(guild_id, user_id)
+    if not rep:
+        return None
+    
+    res = []
+    async with aiosqlite.connect('data/urnby.db') as db:
+        db.row_factory = aiosqlite.Row
+        query = f"""SELECT * FROM reps WHERE server = {guild_id} AND in_timestamp < {rep.in_timestamp}"""
+        async with db.execute(query) as cursor:
+            rows = await cursor.fetchall()
+            res = [dict(row) for row in rows]
+    return res
+
     # ==============================================================================
     # Misc
     # ============================================================================== 


### PR DESCRIPTION
- When a user who is on the rep list, clocks in, all replacements which are OLDER than this replacement are removed from the list
- Prevent an active user from joining the rep list
- Have Clocks cog use CampQueue to interface with rep list, instead of db access


One case where auto-removing reps from list could be wonky is in the case where 2+ spots open up at the same time. If the 2nd person in list clocks in first then it wipes out the 1st person... which shouldn't be an issue because that 2nd person should only clockin knowing the first one is going to clock in anyways, otherwise they'd have to wait. 

Another enhancement could be to prompt the person clocking in with an option box if those OLDER reps should be removed, added to end of list, or left alone to let them choose the action. 